### PR TITLE
interval autofocus cancel before capture

### DIFF
--- a/photobooth/services/backends/picamera2.py
+++ b/photobooth/services/backends/picamera2.py
@@ -427,6 +427,9 @@ class Picamera2Backend(AbstractBackend):
                 # only capture one pic and return to lores streaming afterwards
                 self._hires_data.request_ready.clear()
 
+                # ensure before shoot that no focus is active; module may decide how to handle or cancel current run
+                self._autofocus_module.ensure_focused()
+
                 self._evtbus.emit("frameserver/onCapture")
 
                 # capture hq picture

--- a/photobooth/services/backends/picamera2_libcamafcontinuous.py
+++ b/photobooth/services/backends/picamera2_libcamafcontinuous.py
@@ -49,6 +49,10 @@ class Picamera2LibcamAfContinuous:
     def stop(self):
         """stop backend"""
 
+    def ensure_focused(self):
+        """ensure before shoot the focus algorithm is not currently in progress"""
+        # nothing to do here.
+
     def _on_thrill(self):
         """nothing to do in continous mode here"""
 


### PR DESCRIPTION
to avoid blurry photos, cancel the autofocus algorithm and revert to previous position if active right before capture.